### PR TITLE
Removed Extraneous File Declaration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,10 +3,6 @@
     "version": "0.0.1",
     "description": "Select a random line from a text document.",
     "manifest_version": 2,
-	"background": {
-		"scripts": ["background.js"],
-		"persistent": true
-	},
     "browser_action": {
 		"default_popup": "popup.html",
 		"default_title": "RandomSelection"


### PR DESCRIPTION
I am proposing that y'all remove the background script declaration from your manifest file for two reasons:
1) You already have background.js as an embedded script in your popup.html and as such running it in the background is not required as you are already running the file from the popup and you won't need to run the script while the popup isn't currently active.

2) You had "persistent" set to true for the background script which means the script was always running in the background which will just suck up system resources that aren't required.